### PR TITLE
Finish describe_regions API

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,8 +82,7 @@ fn signature(api_params: Vec<(String, String)>) -> Vec<(String, String)> {
     return signed_params;
 }
 
-/*
-fn describe_region() {
+fn describe_regions() {
     let mut url = Url::parse(ALIYUN_API).unwrap();
     let params = signature(vec![
         ("Action".to_string(), "DescribeRegions".to_string()),
@@ -91,15 +90,16 @@ fn describe_region() {
     url.query_pairs_mut().extend_pairs(params.into_iter());
     let client = reqwest::Client::new().unwrap();
     let mut text = String::new();
-    let res = client.get(url)
+    client.get(url)
         .send()
         .unwrap()
         .read_to_string(&mut text)
         .unwrap();
-    let data = Json::from_str(&text).unwrap();
-    println!("{}", data);
+    let response = serde_json::from_str::<rep::Regions>(&text).unwrap();
+    for region in &response.regions {
+        println!("{}\t{}", region.id, region.name);
+    }
 }
- */
 
 fn ping_ok(ip: &str) -> bool {
     let output = Command::new("ping")
@@ -251,6 +251,9 @@ fn main() {
                             instance.ip()
                 );
             }
+        }
+        "regions" => {
+            describe_regions();
         }
         _ => println!("Unknown command."),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,13 +89,11 @@ fn describe_regions() {
         ("RegionId".to_string(), "cn-hangzhou".to_string())]);
     url.query_pairs_mut().extend_pairs(params.into_iter());
     let client = reqwest::Client::new().unwrap();
-    let mut text = String::new();
-    client.get(url)
+    let response = client.get(url)
         .send()
         .unwrap()
-        .read_to_string(&mut text)
+        .json::<rep::Regions>()
         .unwrap();
-    let response = serde_json::from_str::<rep::Regions>(&text).unwrap();
     for region in &response.regions {
         println!("{}\t{}", region.id, region.name);
     }
@@ -140,14 +138,12 @@ fn get_instances() -> Vec<rep::Instance> {
                                 ("RegionId".to_string(), "cn-beijing".to_string())]);
     url.query_pairs_mut().extend_pairs(params.into_iter());
     let client = reqwest::Client::new().unwrap();
-    let mut text = String::new();
-    client
+    let response = client
         .get(url)
         .send()
         .unwrap()
-        .read_to_string(&mut text)
+        .json::<rep::Instances>()
         .unwrap();
-    let response = serde_json::from_str::<rep::Instances>(&text).unwrap();
     return response.instances;
 }
 

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -32,6 +32,21 @@ pub struct Instances {
     pub size: usize,
 }
 
+#[derive(Debug, Deserialize, Clone)]
+pub struct Region {
+    #[serde(rename = "RegionId")]
+    pub id: String,
+    #[serde(rename = "LocalName")]
+    pub name: String
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Regions {
+    #[serde(deserialize_with = "deserialize_single_key_map")]
+    #[serde(rename = "Regions")]
+    pub regions: Vec<Region>,
+}
+
 fn deserialize_single_key_map<V, D>(d: D) -> Result<V, D::Error>
     where D: Deserializer,
           V: Deserialize


### PR DESCRIPTION
```
     Running `target/debug/ali-ecs-ctl regions`
cn-shenzhen	华南 1
ap-southeast-1	亚太东南 1 (新加坡)
cn-qingdao	华北 1
cn-beijing	华北 2
cn-zhangjiakou	华北 3
cn-shanghai	华东 2
us-east-1	美国东部 1 (弗吉尼亚)
cn-hongkong	香港
me-east-1	中东东部 1 (迪拜)
ap-southeast-2	亚太东南 2 (悉尼)
cn-hangzhou	华东 1
eu-central-1	欧洲中部 1 (法兰克福)
ap-northeast-1	亚太东北 1 (东京)
us-west-1	美国西部 1 (硅谷)
```